### PR TITLE
Add compatibility with Hardhat

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -22,7 +22,19 @@ export const send = (provider: any, method: string, params?: any[]) => new Promi
   if (_provider.sendAsync) {
     _provider.sendAsync(payload, callback);
   } else {
-    _provider.send(payload, callback);
+    _provider.send(payload, callback).catch((error: any) => {
+      if (
+        error.message ===
+        "Hardhat Network doesn't support JSON-RPC params sent as an object"
+      ) {
+        _provider
+          .send(method, params)
+          .then((r: any) => resolve(r))
+          .catch((e: any) => reject(e));
+      } else {
+        throw error;
+      }
+    });
   }
 });
 


### PR DESCRIPTION
This allows for the `signDaiPermit` and `signERC2612Permit` functions to be used in Hardhat tests